### PR TITLE
Cryptichain Pull Request

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function(grunt) {
+module.exports = function (grunt) {
 
     // Load NPM Tasks
     grunt.loadNpmTasks('grunt-contrib-uglify');
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
         pkg: grunt.file.readJSON('package.json'),
         concat: {
             options: {
-                process: function(src, filepath) {
+                process: function (src, filepath) {
                     if (filepath.substr(filepath.length - 2) === 'js') {
                         return '// Source: ' + filepath + '\n' +
                         src.replace(/(^|\n)[ \t]*('use strict'|"use strict");?\s*/g, '$1');

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Example:
    * `enableExchange` - enable or disable exchange currency courses.
    * `updateExchangeInterval` - time to update exchange currency courses.
    * `btcusdExchange` - default is bitfinex, alternatives are: bitstamp & btce.
-   * `xcrbtcExchange` - default is poloniex, alternatives are: cryptsy.
+   * `xcrbtcExchange` - default is poloniex, alternatives are: bter & cryptsy.
 
 # Build
 

--- a/api/statistics.js
+++ b/api/statistics.js
@@ -1,29 +1,31 @@
 var api = require('../lib/api');
 
 module.exports = function (app) {
+    var statistics = new api.statistics(app);
+
     app.get('/api/statistics/getBestBlock', function (req, res) {
-        new api.statistics(app).getBestBlock(
+        statistics.getBestBlock(
             function (data) { res.json(data); },
             function (data) { res.json(data); }
         );
     });
 
     app.get('/api/statistics/getLastBlock', function (req, res) {
-        new api.statistics(app).getLastBlock(
+        statistics.getLastBlock(
             function (data) { res.json(data); },
             function (data) { res.json(data); }
         );
     });
 
     app.get('/api/statistics/getVolume', function (req, res) {
-        new api.statistics(app).getVolume(
+        statistics.getVolume(
             function (data) { res.json(data); },
             function (data) { res.json(data); }
         );
     });
 
     app.get('/api/statistics/getPeers', function (req, res) {
-        new api.statistics(app).getPeers(
+        statistics.getPeers(
             function (data) { res.json(data); },
             function (data) { res.json(data); }
         );

--- a/api/statistics.js
+++ b/api/statistics.js
@@ -24,7 +24,6 @@ module.exports = function (app) {
 
     app.get('/api/statistics/getPeers', function (req, res) {
         new api.statistics(app).getPeers(
-            req.query.address,
             function (data) { res.json(data); },
             function (data) { res.json(data); }
         );

--- a/api/transactions.js
+++ b/api/transactions.js
@@ -25,7 +25,9 @@ module.exports = function (app) {
 
     app.get("/api/getTransactionsByAddress", function (req, res, next) {
         new api.transactions(app).getTransactionsByAddress(
-            req.query.address,
+            { address : req.query.address,
+              offset  : req.query.offset,
+              limit   : req.query.limit },
             function (data) { res.json(data); },
             function (data) { req.json = data; return next(); }
         );

--- a/app.js
+++ b/app.js
@@ -22,7 +22,6 @@ if (config.redis.password) {
 }
 
 var utils = require('./utils'),
-    time = utils.time,
     topAccounts = utils.topAccounts;
 
 var app = express();
@@ -35,16 +34,6 @@ app.configure(function () {
 
     app.set("crypti address", "http://" + config.crypti.host + ":" + config.crypti.port);
     app.set("freegeoip address", "http://" + config.freegeoip.host + ":" + config.freegeoip.port);
-
-    app.use(function (req, res, next) {
-        req.crypti = app.get("crypti address");
-        return next();
-    });
-
-    app.use(function (req, res, next) {
-        req.time = time;
-        return next();
-    });
 
     app.set("fixed point", config.fixedPoint);
 

--- a/lib/api/blocks.js
+++ b/lib/api/blocks.js
@@ -48,7 +48,7 @@ module.exports = function (app) {
     }
 
     this.getBlock = function (blockId, error, success) {
-        if (blockId == null) {
+        if (!blockId) {
             return error({ success : false });
         }
         this.getBlocksCount(

--- a/lib/api/blocks.js
+++ b/lib/api/blocks.js
@@ -19,8 +19,8 @@ module.exports = function (app) {
 
     this.lastBlocks = function (p, error, success) {
         this.getBlocksCount(
-            function(data) { return error({ success : false }); },
-            function(data) {
+            function (data) { return error({ success : false }); },
+            function (data) {
                 if (data.success == true) {
                     var height = data.count;
 
@@ -52,8 +52,8 @@ module.exports = function (app) {
             return error({ success : false });
         }
         this.getBlocksCount(
-            function(data) { return error({ success : false }); },
-            function(data) {
+            function (data) { return error({ success : false }); },
+            function (data) {
                 if (data.success == false) {
                     return error({ success : false });
                 } else {

--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -257,10 +257,10 @@ module.exports = function (app) {
         }
 
         this.process = function (p, next) {
-            p.dottedQuad = num2ip(p.ip);
-            p.osBrand    = osBrand(p.os);
+            p.ipString = num2ip(p.ip);
+            p.osBrand  = osBrand(p.os);
 
-            this.ips.push(p.dottedQuad);
+            this.ips.push(p.ipString);
 
             switch (parseInt(p.state)) {
                 case 1:
@@ -270,7 +270,7 @@ module.exports = function (app) {
                 case 2:
                     p.humanState = 'Connected';
                     this.list.connected.push(p);
-                    this.locations.locate(p.dottedQuad, function (res) {
+                    this.locations.locate(p.ipString, function (res) {
                         p.location = res;
                         return next();
                     });

--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -33,10 +33,9 @@ module.exports = function (app) {
     }
 
     this.getBestBlock = function (error, success) {
-        var offset    = 0,
-            limit     = 100,
-            blocks    = new Blocks(),
-            found     = false;
+        var offset = 0,
+            limit  = 100,
+            blocks = new Blocks();
 
         async.doUntil(
             function (next) {
@@ -54,9 +53,8 @@ module.exports = function (app) {
             },
             function () {
                 offset += limit;
-                found   = (offset > blocks.maxOffset);
 
-                return found;
+                return (offset > blocks.maxOffset);
             },
             function (err) {
                 if (err) {
@@ -154,9 +152,8 @@ module.exports = function (app) {
             },
             function () {
                 offset += limit;
-                found   = (offset > transactions.maxOffset);
 
-                return found;
+                return found || (offset > transactions.maxOffset);
             },
             function (err) {
                 if (err) {
@@ -336,9 +333,8 @@ module.exports = function (app) {
             },
             function () {
                 offset += limit;
-                found   = (offset > peers.maxOffset);
 
-                return found;
+                return found || (offset > peers.maxOffset);
             },
             function (err) {
                 peers.locations.update(peers.ips);

--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -213,7 +213,7 @@ module.exports = function (app) {
             p.dottedQuad = num2ip(p.ip);
             p.osBrand    = osBrand(p.os);
 
-            switch(parseInt(p.state)) {
+            switch (parseInt(p.state)) {
                 case 1:
                     p.humanState = 'Disconnected';
                     this.list.disconnected.push(p);

--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -206,6 +206,7 @@ module.exports = function (app) {
                 json : true
             }, function (err, resp, body) {
                 if (err || resp.statusCode != 200) {
+                    console.error('Locator:', 'Failed to get new location for:', ip);
                     return cb(null);
                 } else {
                     cache[ip] = body;

--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -47,12 +47,12 @@ module.exports = function (app) {
                 }, function (err, resp, body) {
                     if (err || resp.statusCode != 200) {
                         return next(err || "Status code is not equal 200");
-                    } else {
-                        blocks.best(body.blocks, bestBlock, function (res) {
-                            bestBlock = res.bestBlock;
-                            found     = res.found;
-                        });
                     }
+
+                    blocks.best(body.blocks, bestBlock, function (res) {
+                        bestBlock = res.bestBlock;
+                        found     = res.found;
+                    });
 
                     return next();
                 });
@@ -83,7 +83,9 @@ module.exports = function (app) {
         }, function (err, resp, body) {
             if (err || resp.statusCode != 200) {
                 return next(err || "Status code is not equal 200");
-            } else if (any(body.blocks)) {
+            }
+
+            if (any(body.blocks)) {
                 return success({ success: true, block: body.blocks[0] });
             } else {
                 return error({ success: false });
@@ -144,7 +146,9 @@ module.exports = function (app) {
                 }, function (err, resp, body) {
                     if (err || resp.statusCode != 200) {
                         return next(err || "Status code is not equal 200");
-                    } else if (any(body.transactions)) {
+                    }
+
+                    if (any(body.transactions)) {
                         transactions.collect(body.transactions);
                     } else {
                         found = true;
@@ -288,11 +292,14 @@ module.exports = function (app) {
                 }, function (err, resp, body) {
                     if (err || resp.statusCode != 200) {
                         return next(err || "Status code is not equal 200");
-                    } else if (any(body.peers)) {
+                    }
+
+                    if (any(body.peers)) {
                         peers.collect(body.peers);
                     } else {
                         found = true;
                     }
+
                     return next();
                 });
             },

--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -221,7 +221,7 @@ module.exports = function (app) {
                 case 2:
                     p.humanState = 'Connected';
                     this.list.connected.push(p);
-                    geoLocate(p.dottedQuad, function(res) {
+                    geoLocate(p.dottedQuad, function (res) {
                         p.location = res;
                         return next();
                     });
@@ -259,7 +259,7 @@ module.exports = function (app) {
           }
         }
 
-        var geoLocate = function(ip, cb) {
+        var geoLocate = function (ip, cb) {
             request.get({
                 url: app.get("freegeoip address") + '/json/' + ip,
                 json : true

--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -4,37 +4,37 @@ var request = require('request'),
 module.exports = function (app) {
     function Blocks () {
         this.maxOffset = 200; // 300 (5 Hours)
+        this.best      = null;
 
         this.url = function (offset, limit) {
             return url("/api/blocks?&orderBy=height:desc", offset, limit);
         },
 
-        this.best = function (blocks, bestBlock) {
-            if (!any(blocks)) { return bestBlock; }
+        this.findBest = function (blocks) {
+            if (!any(blocks)) { return this.best; }
 
             for (var i = 0; i < blocks.length; i++) {
                 var newBlock = blocks[i];
 
-                if (bestBlock) {
-                    var bestAmount = bestBlock.totalAmount + bestBlock.totalFee,
+                if (this.best) {
+                    var bestAmount = this.best.totalAmount + this.best.totalFee,
                         newAmount = newBlock.totalAmount + newBlock.totalFee;
 
                     if (bestAmount < newAmount) {
-                        bestBlock = newBlock;
+                        this.best = newBlock;
                     }
                 } else {
-                    bestBlock = newBlock;
+                    this.best = newBlock;
                 }
             }
 
-            return bestBlock;
+            return this.best;
         }
     }
 
     this.getBestBlock = function (error, success) {
         var offset    = 0,
             limit     = 100,
-            bestBlock = null,
             blocks    = new Blocks(),
             found     = false;
 
@@ -48,7 +48,7 @@ module.exports = function (app) {
                         return next(err || "Status code is not equal 200");
                     }
 
-                    bestBlock = blocks.best(body.blocks, bestBlock);
+                    blocks.findBest(body.blocks);
                     return next();
                 });
             },
@@ -63,7 +63,7 @@ module.exports = function (app) {
                     console.log("Error retrieving best block: " + err);
                     return error({ success: false });
                 } else {
-                    return success({ success: true, block: bestBlock });
+                    return success({ success: true, block: blocks.best });
                 }
             }
         )

--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -174,13 +174,59 @@ module.exports = function (app) {
         )
     }
 
-    function Peers () {
+    function Locator () {
+        this.locate = function (ip, cb) {
+            var location = null;
+
+            if (location = cache[ip]) {
+                console.log('Locator:', 'Using cached location for:', ip);
+                return cb(location);
+            } else {
+                console.log('Locator:', 'Requesting new location for:', ip);
+                return getLocation(ip, cb);
+            }
+        }
+
+        this.update = function (ips) {
+            for (var ip in cache) {
+                if (ips.indexOf(ip) == -1) {
+                    console.log('Locator', 'Removing stale location:', ip);
+                    delete cache[ip];
+                }
+            }
+        }
+
+        // Private
+
+        var cache = {};
+
+        var getLocation = function (ip, cb) {
+            request.get({
+                url: app.get("freegeoip address") + '/json/' + ip,
+                json : true
+            }, function (err, resp, body) {
+                if (err || resp.statusCode != 200) {
+                    return cb(null);
+                } else {
+                    cache[ip] = body;
+                    return cb(body);
+                }
+            });
+        }
+    }
+
+    this.locator = new Locator();
+
+    function Peers (locator) {
         this.maxOffset = 900; // 1000
 
         this.list = {
             connected:    [], // 1
             disconnected: []  // 2
         }
+
+        this.ips       = [];
+        this.locations = locator;
 
         this.url = function (offset, limit) {
             return url("/api/peers?orderBy=ip:asc", offset, limit);
@@ -213,6 +259,8 @@ module.exports = function (app) {
             p.dottedQuad = num2ip(p.ip);
             p.osBrand    = osBrand(p.os);
 
+            this.ips.push(p.dottedQuad);
+
             switch (parseInt(p.state)) {
                 case 1:
                     p.humanState = 'Disconnected';
@@ -221,7 +269,7 @@ module.exports = function (app) {
                 case 2:
                     p.humanState = 'Connected';
                     this.list.connected.push(p);
-                    geoLocate(p.dottedQuad, function (res) {
+                    this.locations.locate(p.dottedQuad, function (res) {
                         p.location = res;
                         return next();
                     });
@@ -258,25 +306,12 @@ module.exports = function (app) {
               return 3; // Unknown
           }
         }
-
-        var geoLocate = function (ip, cb) {
-            request.get({
-                url: app.get("freegeoip address") + '/json/' + ip,
-                json : true
-            }, function (err, resp, body) {
-                if (err || resp.statusCode != 200) {
-                    return cb(null);
-                } else {
-                    return cb(body);
-                }
-            });
-        }
     }
 
     this.getPeers = function (error, success) {
         var offset = 0,
             limit  = 100,
-            peers  = new Peers(),
+            peers  = new Peers(this.locator),
             found  = false;
 
         async.doUntil(
@@ -305,6 +340,8 @@ module.exports = function (app) {
                 return found;
             },
             function (err) {
+                peers.locations.update(peers.ips);
+
                 if (err) {
                     console.log("Error retrieving peers: " + err);
                     return error({ success: false });

--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -9,26 +9,25 @@ module.exports = function (app) {
             return url("/api/blocks?&orderBy=height:desc", offset, limit);
         },
 
-        this.best = function (blocks, bestBlock, cb) {
-            if (any(blocks)) {
-                for (var i = 0; i < blocks.length; i++) {
-                    var newBlock = blocks[i];
+        this.best = function (blocks, bestBlock) {
+            if (!any(blocks)) { return bestBlock; }
 
-                    if (bestBlock) {
-                        var bestAmount = bestBlock.totalAmount + bestBlock.totalFee,
-                            newAmount = newBlock.totalAmount + newBlock.totalFee;
+            for (var i = 0; i < blocks.length; i++) {
+                var newBlock = blocks[i];
 
-                        if (bestAmount < newAmount) {
-                            bestBlock = newBlock;
-                        }
-                    } else {
+                if (bestBlock) {
+                    var bestAmount = bestBlock.totalAmount + bestBlock.totalFee,
+                        newAmount = newBlock.totalAmount + newBlock.totalFee;
+
+                    if (bestAmount < newAmount) {
                         bestBlock = newBlock;
                     }
+                } else {
+                    bestBlock = newBlock;
                 }
-                return cb({ found: false, bestBlock: bestBlock });
-            } else {
-                return cb({ found: true });
             }
+
+            return bestBlock;
         }
     }
 
@@ -49,11 +48,7 @@ module.exports = function (app) {
                         return next(err || "Status code is not equal 200");
                     }
 
-                    blocks.best(body.blocks, bestBlock, function (res) {
-                        bestBlock = res.bestBlock;
-                        found     = res.found;
-                    });
-
+                    bestBlock = blocks.best(body.blocks, bestBlock);
                     return next();
                 });
             },

--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -146,7 +146,6 @@ module.exports = function (app) {
                         return next(err || "Status code is not equal 200");
                     } else if (any(body.transactions)) {
                         transactions.collect(body.transactions);
-                        found = false;
                     } else {
                         found = true;
                     }
@@ -290,7 +289,6 @@ module.exports = function (app) {
                     if (err || resp.statusCode != 200) {
                         return next(err || "Status code is not equal 200");
                     } else if (any(body.peers)) {
-                        found = false;
                         peers.collect(body.peers);
                     } else {
                         found = true;

--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -82,7 +82,7 @@ module.exports = function (app) {
             json : true
         }, function (err, resp, body) {
             if (err || resp.statusCode != 200) {
-                return next(err || "Status code is not equal 200");
+                return error({ success: false });
             }
 
             if (any(body.blocks)) {

--- a/lib/api/transactions.js
+++ b/lib/api/transactions.js
@@ -105,7 +105,7 @@ module.exports = function (app) {
 
     var exchange = app.exchange;
 
-    var concatenate = function(transactions, body) {
+    var concatenate = function (transactions, body) {
         transactions = transactions.concat(body.transactions);
         transactions.sort(function (a, b) {
             if (a.timestamp > b.timestamp)

--- a/lib/api/transactions.js
+++ b/lib/api/transactions.js
@@ -65,12 +65,22 @@ module.exports = function (app) {
         }.bind(this));
     }
 
-    this.getTransactionsByAddress = function (address, error, success) {
-        if (!address) {
+    this.getTransactionsByAddress = function (query, error, success) {
+        if (!query.address) {
             return error({ success : false });
         }
+
+        var url = [
+            app.get("crypti address"),
+            "/api/transactions?recipientId=", query.address,
+            "&senderId=", query.address,
+            "&orderBy=timestamp:desc",
+            "&offset=", param(query.offset, 0),
+            "&limit=", param(query.limit, 100)
+        ].join('');
+
         request.get({
-            url : app.get("crypti address") + "/api/transactions?recipientId=" + address + "&senderId=" + address + "&orderBy=timestamp:desc",
+            url : url,
             json : true
         }, function (err, response, body) {
             if (err || response.statusCode != 200) {
@@ -104,6 +114,16 @@ module.exports = function (app) {
     // Private
 
     var exchange = app.exchange;
+
+    var param = function (p, d) {
+        p = parseInt(p);
+
+        if (isNaN(p) || p < 0) {
+            return p = d;
+        } else {
+            return p;
+        }
+    }
 
     var concatenate = function (transactions, body) {
         transactions = transactions.concat(body.transactions);

--- a/lib/api/transactions.js
+++ b/lib/api/transactions.js
@@ -70,17 +70,13 @@ module.exports = function (app) {
             return error({ success : false });
         }
 
-        var url = [
-            app.get("crypti address"),
-            "/api/transactions?recipientId=", query.address,
-            "&senderId=", query.address,
-            "&orderBy=timestamp:desc",
-            "&offset=", param(query.offset, 0),
-            "&limit=", param(query.limit, 100)
-        ].join('');
-
         request.get({
-            url : url,
+            url : app.get("crypti address")
+                      + "/api/transactions?recipientId=" + query.address
+                      + "&senderId=" + query.address
+                      + "&orderBy=timestamp:desc"
+                      + "&offset=" + param(query.offset, 0)
+                      + "&limit=" + param(query.limit, 100),
             json : true
         }, function (err, response, body) {
             if (err || response.statusCode != 200) {

--- a/lib/api/transactions.js
+++ b/lib/api/transactions.js
@@ -3,11 +3,11 @@ var request = require('request'),
 
 module.exports = function (app) {
     this.getTransaction = function (transactionId, error, success, url) {
-        if (url == null) {
+        if (!url) {
             var confirmed = true;
             url = "/api/transactions/get?id=";
         }
-        if (transactionId == null) {
+        if (!transactionId) {
             return error({ success : false });
         }
         request.get({
@@ -66,7 +66,7 @@ module.exports = function (app) {
     }
 
     this.getTransactionsByAddress = function (address, error, success) {
-        if (address == null) {
+        if (!address) {
             return error({ success : false });
         }
         request.get({
@@ -84,7 +84,7 @@ module.exports = function (app) {
     }
 
     this.getTransactionsByBlock = function (blockId, error, success) {
-        if (blockId == null) {
+        if (!blockId) {
             return error({ success : false });
         }
         request.get({

--- a/public/src/css/common.css
+++ b/public/src/css/common.css
@@ -266,7 +266,7 @@ a, a:hover, a:visited, a:focus {
 .navbar-brand .logo {
   background-image: url(/img/logo.png);
   background-size: 250px 56px;
-  background-position: -125px 1px;
+  background-position: -125px 0px;
   height: 56px;
   width: 125px;
 }

--- a/public/src/css/networkMonitor.css
+++ b/public/src/css/networkMonitor.css
@@ -30,6 +30,25 @@ p.big-details span.connected-peers {
   border: 1px solid #373D42;
 }
 
+#map .leaflet-popup-content p,
+#map .leaflet-popup-content span {
+  margin: 0;
+  padding: 0;
+}
+
+#map .leaflet-popup-content p.ip {
+  font-weight: bold;
+  margin-bottom: 5px;
+  border-bottom: 1px solid #373D42;
+}
+
+#map .leaflet-popup-content span.label {
+  display: inline-block;
+  width: 50px;
+  text-align: left;
+  color: #373D42;
+}
+
 div.platforms {
   text-align: center;
   min-height: 58px;

--- a/public/src/js/config.js
+++ b/public/src/js/config.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Setting up routes
-angular.module('cryptichain').config(function($routeProvider) {
+angular.module('cryptichain').config(function ($routeProvider) {
     $routeProvider.
     when('/block/:blockId', {
         templateUrl: '/views/block.html',
@@ -51,17 +51,17 @@ angular.module('cryptichain').config(function($routeProvider) {
 
 // Setting HTML5 location mode
 angular.module('cryptichain')
-  .config(function($locationProvider) {
+  .config(function ($locationProvider) {
       $locationProvider.html5Mode(true);
       $locationProvider.hashPrefix('!');
   })
-  .run(function($rootScope, $route, $location, $routeParams, $anchorScroll, ngProgress, gettextCatalog) {
+  .run(function ($rootScope, $route, $location, $routeParams, $anchorScroll, ngProgress, gettextCatalog) {
       gettextCatalog.currentLanguage = 'en';
-      $rootScope.$on('$routeChangeStart', function() {
+      $rootScope.$on('$routeChangeStart', function () {
           ngProgress.start();
       });
 
-      $rootScope.$on('$routeChangeSuccess', function() {
+      $rootScope.$on('$routeChangeSuccess', function () {
           ngProgress.complete();
 
           // Change page title, based on route information

--- a/public/src/js/controllers/activityGraph.js
+++ b/public/src/js/controllers/activityGraph.js
@@ -1,6 +1,6 @@
 'use strict';
 
 angular.module('cryptichain.tools').controller('ActivityGraph',
-  function(activityGraph, $scope) {
+  function (activityGraph, $scope) {
       activityGraph($scope);
   });

--- a/public/src/js/controllers/address.js
+++ b/public/src/js/controllers/address.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('cryptichain.address').controller('AddressController',
-  function($scope, $rootScope, $routeParams, $location, $http) {
+  function ($scope, $rootScope, $routeParams, $location, $http) {
       $scope.getAddress = function () {
           $http.get("/api/getAccount", {
               params : {

--- a/public/src/js/controllers/address.js
+++ b/public/src/js/controllers/address.js
@@ -16,12 +16,14 @@ angular.module('cryptichain.address').controller('AddressController',
 
       $scope.loadTxs = function () {
           Pager.disable();
+          $scope.loading = true;
           Pager.getTxs(0, (Pager.limit + 1),
               function (resp) { Pager.loadTxs(resp) });
       }
 
       $scope.loadMore = function () {
           Pager.disable();
+          $scope.loading = true;
           Pager.getTxs(0, 1, function (resp) {
               var changed = false;
 
@@ -79,6 +81,7 @@ angular.module('cryptichain.address').controller('AddressController',
               resp.data.transactions.splice(-1, 1);
               $scope.txs = resp.data.transactions;
               $scope.lessTxs = this.lessTxs($scope.txs.length);
+              $scope.loading = false;
           },
 
           moreTxs : function (length) {
@@ -93,6 +96,7 @@ angular.module('cryptichain.address').controller('AddressController',
                   $scope.moreTxs = false;
               }
               $scope.lessTxs = this.lessTxs($scope.txs.length);
+              $scope.loading = false;
           },
 
           nextOffset : function () {

--- a/public/src/js/controllers/address.js
+++ b/public/src/js/controllers/address.js
@@ -76,9 +76,17 @@ angular.module('cryptichain.address').controller('AddressController',
               });
           },
 
+          spliceTxs : function (resp) {
+              if (resp.data.transactions.length > 1) {
+                  $scope.moreTxs = this.moreTxs(resp.data.transactions.length);
+                  resp.data.transactions.splice(-1, 1);
+              } else {
+                  $scope.moreTxs = false;
+              }
+          },
+
           loadTxs : function (resp) {
-              $scope.moreTxs = this.moreTxs(resp.data.transactions.length);
-              resp.data.transactions.splice(-1, 1);
+              this.spliceTxs(resp);
               $scope.txs = resp.data.transactions;
               $scope.lessTxs = this.lessTxs($scope.txs.length);
               $scope.loading = false;
@@ -89,8 +97,7 @@ angular.module('cryptichain.address').controller('AddressController',
           },
 
           loadMore : function (resp) {
-              $scope.moreTxs = this.moreTxs(resp.data.transactions.length);
-              resp.data.transactions.splice(-1, 1);
+              this.spliceTxs(resp);
               $scope.txs = $scope.txs.concat(resp.data.transactions);
               if ($scope.txs.length + this.limit > 1000) {
                   $scope.moreTxs = false;

--- a/public/src/js/controllers/address.js
+++ b/public/src/js/controllers/address.js
@@ -77,8 +77,10 @@ angular.module('cryptichain.address').controller('AddressController',
           },
 
           spliceTxs : function (resp) {
-              if (resp.data.transactions.length > 1) {
-                  $scope.moreTxs = this.moreTxs(resp.data.transactions.length);
+              var length = resp.data.transactions.length;
+
+              if (length > 1 && length % this.limit == 1) {
+                  $scope.moreTxs = this.moreTxs(length);
                   resp.data.transactions.splice(-1, 1);
               } else {
                   $scope.moreTxs = false;

--- a/public/src/js/controllers/blocks.js
+++ b/public/src/js/controllers/blocks.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('cryptichain.blocks').controller('BlocksController',
-  function($scope, $rootScope, $routeParams, $location, $http, $interval) {
+  function ($scope, $rootScope, $routeParams, $location, $http, $interval) {
       $scope.getLastBlocks = function (n) {
           var offset = 0;
           if (n) {

--- a/public/src/js/controllers/blocks.js
+++ b/public/src/js/controllers/blocks.js
@@ -4,9 +4,12 @@ angular.module('cryptichain.blocks').controller('BlocksController',
   function ($scope, $rootScope, $routeParams, $location, $http, $interval) {
       $scope.getLastBlocks = function (n) {
           var offset = 0;
+
           if (n) {
               offset = (n - 1) * 20;
           }
+
+          $scope.loading = true;
 
           $http.get("/api/lastBlocks?n=" + offset).then(function (resp) {
               if (resp.data.success) {
@@ -18,10 +21,14 @@ angular.module('cryptichain.blocks').controller('BlocksController',
               } else {
                   $scope.blocks = [];
               }
+
+              $scope.loading = false;
           });
       }
 
       $scope.getBlock = function (blockId) {
+          $scope.loading = true;
+
           $http.get("/api/getBlock", {
               params : {
                   blockId : blockId
@@ -40,6 +47,7 @@ angular.module('cryptichain.blocks').controller('BlocksController',
           }).then(function (resp) {
               if (resp.data.success) {
                   $scope.block.transactions = resp.data.transactions;
+                  $scope.loading = false;
               } else {
                   throw 'Block transactions were not found!'
               }

--- a/public/src/js/controllers/footer.js
+++ b/public/src/js/controllers/footer.js
@@ -1,6 +1,6 @@
 'use strict';
 
 angular.module('cryptichain.system').controller('FooterController',
-  function($scope) {
+  function ($scope) {
 
   });

--- a/public/src/js/controllers/header.js
+++ b/public/src/js/controllers/header.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('cryptichain.system').controller('HeaderController',
-  function($scope, $rootScope, $modal, $http, $interval) {
+  function ($scope, $rootScope, $modal, $http, $interval) {
       $scope.getHeight = function () {
           $http.get("/api/getBlocksCount").then(function (resp) {
               if (resp.data.success) {

--- a/public/src/js/controllers/index.js
+++ b/public/src/js/controllers/index.js
@@ -4,7 +4,7 @@ var TRANSACTION_DISPLAYED = 20;
 var BLOCKS_DISPLAYED = 20;
 
 angular.module('cryptichain.system').controller('IndexController',
-  function($scope, $http, $interval) {
+  function ($scope, $http, $interval) {
       $scope.getLastBlocks = function () {
           $http.get("/api/lastBlocks").then(function (resp) {
               if (resp.data.success) {

--- a/public/src/js/controllers/networkMonitor.js
+++ b/public/src/js/controllers/networkMonitor.js
@@ -1,6 +1,6 @@
 'use strict';
 
 angular.module('cryptichain.tools').controller('NetworkMonitor',
-  function(networkMonitor, $scope) {
+  function (networkMonitor, $scope) {
       networkMonitor($scope);
   });

--- a/public/src/js/controllers/search.js
+++ b/public/src/js/controllers/search.js
@@ -1,19 +1,19 @@
 'use strict';
 
 angular.module('cryptichain.search').controller('SearchController',
-  function($scope, $routeParams, $location, $timeout, Global, $http) {
+  function ($scope, $routeParams, $location, $timeout, Global, $http) {
       $scope.loading = false;
       $scope.badQuery = false;
 
-      var _badQuery = function() {
+      var _badQuery = function () {
           $scope.badQuery = true;
 
-          $timeout(function() {
+          $timeout(function () {
               $scope.badQuery = false;
           }, 2000);
       };
 
-      var _resetSearch = function() {
+      var _resetSearch = function () {
           $scope.q = '';
           $scope.loading = false;
       };

--- a/public/src/js/controllers/topAccounts.js
+++ b/public/src/js/controllers/topAccounts.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('cryptichain.address').controller('TopAccounts',
-  function($scope, $rootScope, $routeParams, $location, $http) {
+  function ($scope, $rootScope, $routeParams, $location, $http) {
       $scope.getTopAccounts = function () {
           $http.get("/api/getTopAccounts").then(function (resp) {
               if (resp.data.success) {

--- a/public/src/js/controllers/transactions.js
+++ b/public/src/js/controllers/transactions.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('cryptichain.transactions').controller('transactionsController',
-  function($scope, $rootScope, $routeParams, $location, $http) {
+  function ($scope, $rootScope, $routeParams, $location, $http) {
       $scope.getTransaction = function () {
           $http.get("/api/getTransaction", {
               params : {

--- a/public/src/js/controllers/transactions.js
+++ b/public/src/js/controllers/transactions.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('cryptichain.transactions').controller('transactionsController',
+angular.module('cryptichain.transactions').controller('TransactionsController',
   function ($scope, $rootScope, $routeParams, $location, $http) {
       $scope.getTransaction = function () {
           $http.get("/api/getTransaction", {

--- a/public/src/js/directives.js
+++ b/public/src/js/directives.js
@@ -4,8 +4,8 @@ var ZeroClipboard = window.ZeroClipboard;
 
 angular.module('cryptichain')
   .directive('scroll', function ($window) {
-      return function(scope, element, attrs) {
-          angular.element($window).bind('scroll', function() {
+      return function (scope, element, attrs) {
+          angular.element($window).bind('scroll', function () {
               if (this.pageYOffset >= 200) {
                   scope.secondaryNavbar = true;
               } else {
@@ -15,14 +15,14 @@ angular.module('cryptichain')
           });
       };
   })
-  .directive('whenScrolled', function($window) {
+  .directive('whenScrolled', function ($window) {
       return {
           restric: 'A',
-          link: function(scope, elm, attr) {
+          link: function (scope, elm, attr) {
               var pageHeight, clientHeight, scrollPos;
               $window = angular.element($window);
 
-              var handler = function() {
+              var handler = function () {
                   pageHeight = window.document.documentElement.scrollHeight;
                   clientHeight = window.document.documentElement.clientHeight;
                   scrollPos = window.pageYOffset;
@@ -34,13 +34,13 @@ angular.module('cryptichain')
 
               $window.on('scroll', handler);
 
-              scope.$on('$destroy', function() {
+              scope.$on('$destroy', function () {
                   return $window.off('scroll', handler);
               });
           }
       };
   })
-  .directive('clipCopy', function() {
+  .directive('clipCopy', function () {
       ZeroClipboard.config({
           moviePath: '/swf/ZeroClipboard.swf',
           trustedDomains: ['*'],
@@ -52,33 +52,33 @@ angular.module('cryptichain')
           restric: 'A',
           scope: { clipCopy: '=clipCopy' },
           template: '<div class="tooltip fade right in"><div class="tooltip-arrow"></div><div class="tooltip-inner">Copied!</div></div>',
-          link: function(scope, elm) {
+          link: function (scope, elm) {
               var clip = new ZeroClipboard(elm);
 
-              clip.on('load', function(client) {
-                  var onMousedown = function(client) {
+              clip.on('load', function (client) {
+                  var onMousedown = function (client) {
                       client.setText(scope.clipCopy);
                   };
 
                   client.on('mousedown', onMousedown);
 
-                  scope.$on('$destroy', function() {
+                  scope.$on('$destroy', function () {
                       client.off('mousedown', onMousedown);
                   });
               });
 
-              clip.on('noFlash wrongflash', function() {
+              clip.on('noFlash wrongflash', function () {
                   return elm.remove();
               });
           }
       };
   })
-  .directive('osIcon', function() {
+  .directive('osIcon', function () {
       return {
           restric: 'A',
           replace: true,
           template: '<img class="os-icon">',
-          link: function(scope, elm, attr) {
+          link: function (scope, elm, attr) {
               elm[0].alt = elm[0].title = attr.os;
               elm[0].src = '/img/os/'.concat(attr.brand, '.png');
           }

--- a/public/src/js/filters.js
+++ b/public/src/js/filters.js
@@ -15,10 +15,9 @@ angular.module('cryptichain')
   })
   .filter('epochStamp', function () {
       return function (d) {
-          var epochDate = new Date(Date.UTC(2014, 4, 2, 0, 0, 0, 0));
-          var epochTime = parseInt(epochDate.getTime() / 1000);
-
-          return new Date((epochTime + d) * 1000);
+          return new Date(
+              (((Date.UTC(2014, 4, 2, 0, 0, 0, 0) / 1000) + d) * 1000)
+          );
       }
   })
   .filter('timeAgo', function (epochStampFilter) {

--- a/public/src/js/filters.js
+++ b/public/src/js/filters.js
@@ -26,7 +26,7 @@ angular.module('cryptichain')
           return moment(epochStampFilter(timestamp)).fromNow();
       }
   })
-  .filter('timeDistance', function (epochStampFilter) {
+  .filter('timeSpan', function (epochStampFilter) {
       return function (a, b) {
           var a = epochStampFilter(a);
           var d = (a < b) ? (b - a) : (b + a);

--- a/public/src/js/filters.js
+++ b/public/src/js/filters.js
@@ -27,10 +27,9 @@ angular.module('cryptichain')
   })
   .filter('timeSpan', function (epochStampFilter) {
       return function (a, b) {
-          var a = epochStampFilter(a);
-          var d = (a < b) ? (b - a) : (b + a);
-
-          return moment.duration(d).humanize();
+          return moment.duration(
+              epochStampFilter(a) - epochStampFilter(b)
+          ).humanize();
       }
   })
   .filter('timestamp', function (epochStampFilter) {

--- a/public/src/js/init.js
+++ b/public/src/js/init.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.element(document).ready(
-  function() {
+  function () {
       // Init the app
       // angular.bootstrap(document, ['cryptichain']);
   });

--- a/public/src/js/services/activityGraph.js
+++ b/public/src/js/services/activityGraph.js
@@ -99,25 +99,22 @@ var ActivityGraph = function () {
         this.volume = this.txs = this.blocks = this.accounts = 0;
 
         this.refresh = function () {
-            var txs       = this.graph.nodesByType(0);
-            var blocks    = this.graph.nodesByType(1);
-            var accounts  = this.graph.nodesByType(2);
+            var txs      = this.graph.nodesByType(0);
+            var blocks   = this.graph.nodesByType(1);
+            var accounts = this.graph.nodesByType(2);
 
-            this.txs      = txs.size().value();
-            this.volume   = txsVolume(txs);
-            this.blocks   = blocks.size().value();
-            this.timespan = blocksTimespan(blocks);
-            this.accounts = accounts.size().value();
+            this.txs       = txs.size().value();
+            this.volume    = txsVolume(txs);
+            this.blocks    = blocks.size().value();
+            this.beginning = minTime(blocks);
+            this.end       = maxTime(blocks);
+            this.accounts  = accounts.size().value();
         }
 
         var txsVolume = function (chain) {
             return chain.reduce(function (vol, tx) {
                 return vol += tx.amount;
             }, 0).value() / Math.pow(10, 8);
-        }
-
-        var epochTime = function () {
-            return Date.UTC(2014, 4, 2, 0, 0, 0, 0) / 1000;
         }
 
         var minTime = function (chain) {
@@ -134,13 +131,6 @@ var ActivityGraph = function () {
                     return block.timestamp;
                 }
             }).value().timestamp;
-        }
-
-        var blocksTimespan = function (chain) {
-            var max = epochTime() + maxTime(chain) * 1000;
-            var min = epochTime() + minTime(chain) * 1000;
-
-            return moment.duration((max - min)).humanize();
         }
     }
 

--- a/public/src/js/services/activityGraph.js
+++ b/public/src/js/services/activityGraph.js
@@ -245,6 +245,7 @@ ActivityGraph.prototype.addTxSender = function (tx) {
 }
 
 ActivityGraph.prototype.addTxRecipient = function (tx) {
+    if (!tx.recipientId) { return; }
     this.addAccount(tx.recipientId);
     this.addEdge({
         id: tx.id + tx.recipientId + Math.random(),

--- a/public/src/js/services/activityGraph.js
+++ b/public/src/js/services/activityGraph.js
@@ -341,6 +341,10 @@ angular.module('cryptichain.tools').factory('activityGraph',
               ns.removeAllListeners();
           });
 
+          $scope.$on('$locationChangeStart', function (event, next, current) {
+              ns.emit('locationChange');
+          });
+
           return activityGraph;
       }
   });

--- a/public/src/js/services/activityGraph.js
+++ b/public/src/js/services/activityGraph.js
@@ -342,7 +342,7 @@ angular.module('cryptichain.tools').factory('activityGraph',
           });
 
           $scope.$on('$locationChangeStart', function (event, next, current) {
-              ns.emit('locationChange');
+              ns.emit('forceDisconnect');
           });
 
           return activityGraph;

--- a/public/src/js/services/activityGraph.js
+++ b/public/src/js/services/activityGraph.js
@@ -117,9 +117,7 @@ var ActivityGraph = function () {
         }
 
         var epochTime = function () {
-            return parseInt(
-                new Date(Date.UTC(2014, 4, 2, 0, 0, 0, 0)
-            ).getTime() / 1000);
+            return Date.UTC(2014, 4, 2, 0, 0, 0, 0) / 1000;
         }
 
         var minTime = function (chain) {

--- a/public/src/js/services/address.js
+++ b/public/src/js/services/address.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('cryptichain.address').factory('Address',
-  function($resource) {
+  function ($resource) {
       return $resource('/api/addr/:addrStr/?noTxList=1', {
           addrStr: '@addStr'
       }, {

--- a/public/src/js/services/blocks.js
+++ b/public/src/js/services/blocks.js
@@ -2,7 +2,7 @@
 
 angular.module('cryptichain.blocks')
   .factory('Block',
-    function($resource) {
+    function ($resource) {
         return $resource('/api/block/:blockHash', {
             blockHash: '@blockHash'
         }, {
@@ -22,10 +22,10 @@ angular.module('cryptichain.blocks')
         });
   })
   .factory('Blocks',
-    function($resource) {
+    function ($resource) {
         return $resource('/api/blocks');
     })
   .factory('BlockByHeight',
-    function($resource) {
+    function ($resource) {
         return $resource('/api/block-index/:blockHeight');
     });

--- a/public/src/js/services/global.js
+++ b/public/src/js/services/global.js
@@ -2,8 +2,8 @@
 
 //Global service for global variables
 angular.module('cryptichain.system')
-  .factory('Global', [ function() {} ])
+  .factory('Global', [ function () {} ])
   .factory('Version',
-    function($resource) {
+    function ($resource) {
         return $resource('/api/version');
     });

--- a/public/src/js/services/networkMonitor.js
+++ b/public/src/js/services/networkMonitor.js
@@ -27,7 +27,7 @@ var NetworkMonitor = function ($scope) {
     function Versions (peers) {
         var inspect = function () {
             if (angular.isArray(peers)) {
-                return _.uniq(_.map(peers, function(p) { return p.version; })
+                return _.uniq(_.map(peers, function (p) { return p.version; })
                         .sort(), true).reverse().slice(0, 3);
             } else {
                 return [];

--- a/public/src/js/services/networkMonitor.js
+++ b/public/src/js/services/networkMonitor.js
@@ -207,6 +207,10 @@ angular.module('cryptichain.tools').factory('networkMonitor',
               ns.removeAllListeners();
           });
 
+          $scope.$on('$locationChangeStart', function (event, next, current) {
+              ns.emit('locationChange');
+          });
+
           return networkMonitor;
       }
   });

--- a/public/src/js/services/networkMonitor.js
+++ b/public/src/js/services/networkMonitor.js
@@ -119,7 +119,8 @@ var NetworkMap = function () {
     var PlatformIcon = L.Icon.extend({
         options: {
             iconSize:   [32, 41],
-            iconAnchor: [16, 41]
+            iconAnchor: [16, 41],
+            popupAnchor: [0, -41]
         }
     });
 
@@ -145,7 +146,7 @@ var NetworkMap = function () {
                     this.markers[p.ipString] = L.marker(
                         [p.location.latitude, p.location.longitude],
                         { title: p.ipString, icon: platformIcons[p.osBrand] }
-                    ).addTo(this.map)
+                    ).addTo(this.map).bindPopup(popupContent(p))
                 );
             }
             connected.push(p.ipString);
@@ -173,6 +174,33 @@ var NetworkMap = function () {
         return location
             && angular.isNumber(location.latitude)
             && angular.isNumber(location.longitude);
+    }
+
+    var popupContent = function (p) {
+        var content = '<p class="ip">'.concat(p.ipString, '</p>');
+
+        content += '<p class="version">'
+           .concat('<span class="label">Version: </span>', p.version, '</p>');
+
+        content += '<p class="os">'
+           .concat('<span class="label">OS: </span>', p.os, '</p>');
+
+        if (p.location.city) {
+            content += '<p class="city">'
+               .concat('<span class="label">City: </span>', p.location.city, '</p>');
+        }
+
+        if (p.location.region_name) {
+            content += '<p class="region">'
+               .concat('<span class="label">Region: </span>', p.location.region_name, '</p>');
+        }
+
+        if (p.location.country_name) {
+            content += '<p class="country">'
+               .concat('<span class="label">Country: </span>', p.location.country_name, '</p>');
+        }
+
+        return content;
     }
 }
 

--- a/public/src/js/services/networkMonitor.js
+++ b/public/src/js/services/networkMonitor.js
@@ -137,7 +137,7 @@ var NetworkMap = function () {
             var p = peers.connected[i];
 
             if (!validLocation(p.location)) {
-                console.warn('Invalid geo-location data received for:' + p.ipString);
+                console.warn('Invalid geo-location data received for:', p.ipString);
                 continue;
             }
 

--- a/public/src/js/services/networkMonitor.js
+++ b/public/src/js/services/networkMonitor.js
@@ -137,19 +137,19 @@ var NetworkMap = function () {
             var p = peers.connected[i];
 
             if (!validLocation(p.location)) {
-                console.warn('Invalid geo-location data received for:' + p.dottedQuad);
+                console.warn('Invalid geo-location data received for:' + p.ipString);
                 continue;
             }
 
-            if (!_.has(this.markers, p.dottedQuad)) {
+            if (!_.has(this.markers, p.ipString)) {
                 this.cluster.addLayer(
-                    this.markers[p.dottedQuad] = L.marker(
+                    this.markers[p.ipString] = L.marker(
                         [p.location.latitude, p.location.longitude],
-                        { title: p.dottedQuad, icon: platformIcons[p.osBrand] }
+                        { title: p.ipString, icon: platformIcons[p.osBrand] }
                     ).addTo(this.map)
                 );
             }
-            connected.push(p.dottedQuad);
+            connected.push(p.ipString);
         }
 
         this.removeDisconnected(connected);

--- a/public/src/js/services/networkMonitor.js
+++ b/public/src/js/services/networkMonitor.js
@@ -101,7 +101,6 @@ var NetworkMonitor = function ($scope) {
         this.$scope.volAmount    = volume.amount;
         this.$scope.volBeginning = volume.beginning;
         this.$scope.volEnd       = volume.end;
-        this.$scope.volNow       = moment();
     }
 }
 

--- a/public/src/js/services/networkMonitor.js
+++ b/public/src/js/services/networkMonitor.js
@@ -136,6 +136,11 @@ var NetworkMap = function () {
         for (var i = 0; i < peers.connected.length; i++) {
             var p = peers.connected[i];
 
+            if (!validLocation(p.location)) {
+                console.warn('Invalid geo-location data received for:' + p.dottedQuad);
+                continue;
+            }
+
             if (!_.has(this.markers, p.dottedQuad)) {
                 this.cluster.addLayer(
                     this.markers[p.dottedQuad] = L.marker(
@@ -161,6 +166,14 @@ var NetworkMap = function () {
                 delete this.markers[ip];
             }
         }
+    }
+
+    // Private
+
+    var validLocation = function (location) {
+        return location
+            && angular.isNumber(location.latitude)
+            && angular.isNumber(location.longitude);
     }
 }
 

--- a/public/src/js/services/networkMonitor.js
+++ b/public/src/js/services/networkMonitor.js
@@ -208,7 +208,7 @@ angular.module('cryptichain.tools').factory('networkMonitor',
           });
 
           $scope.$on('$locationChangeStart', function (event, next, current) {
-              ns.emit('locationChange');
+              ns.emit('forceDisconnect');
           });
 
           return networkMonitor;

--- a/public/src/js/services/socket.js
+++ b/public/src/js/services/socket.js
@@ -2,7 +2,7 @@
 
 angular.module('cryptichain.socket').factory('$socket',
   function ($location, $rootScope) {
-    return function(namespace) {
+    return function (namespace) {
           var socket = io($location.host() + ':' + $location.port() + namespace, { 'forceNew': true });
 
           return {

--- a/public/src/js/services/socket.js
+++ b/public/src/js/services/socket.js
@@ -3,7 +3,7 @@
 angular.module('cryptichain.socket').factory('$socket',
   function ($location, $rootScope) {
     return function(namespace) {
-          var socket = io($location.host() + ':' + $location.port() + namespace);
+          var socket = io($location.host() + ':' + $location.port() + namespace, { 'forceNew': true });
 
           return {
               on: function (eventName, callback) {

--- a/public/views/404.html
+++ b/public/views/404.html
@@ -1,5 +1,5 @@
 <div class="jumbotron">
   <h1>Ooops!</h1>
   <h2 class="text-muted">404 Page not found :(</h2>
-  <p><a href="/" class="pull-right">Go to home</a></p>
+  <p><a href="/" class="pull-right">Go home</a></p>
 </div>

--- a/public/views/activityGraph.html
+++ b/public/views/activityGraph.html
@@ -53,7 +53,7 @@
       <hr />
 
       <h4>Statistics</h4>
-      <table class="table">
+      <table class="table table-responsive">
         <tr>
           <th>Txs</th>
           <td>{{statistics.txs}}</td>

--- a/public/views/activityGraph.html
+++ b/public/views/activityGraph.html
@@ -68,7 +68,7 @@
         </tr>
         <tr>
           <th>Timespan</th>
-          <td>{{statistics.timespan || '&infin;'}}</td>
+          <td>{{statistics.beginning | timeSpan:statistics.end}}</td>
         </tr>
         <tr>
           <th>Accounts</th>

--- a/public/views/address.html
+++ b/public/views/address.html
@@ -2,8 +2,8 @@
   <div class="secondary_navbar hidden-xs hidden-sm" scroll data-ng-class="{'hidden': !secondaryNavbar}" data-ng-show="address.address">
     <div class="container" data-ng-hide="!address.balance">
       <div class="col-md-8 text-left">
-          <h3>Address</h3> {{address.address}}
-          <span class="btn-copy" clip-copy="address.address"></span>
+        <h3>Address</h3> {{address.address}}
+        <span class="btn-copy" clip-copy="address.address"></span>
       </div>
       <div class="col-md-4">
         <span class="txvalues txvalues-primary"><strong>Final Balance</strong> {{address.balance | xcr}} XCR</span>
@@ -36,8 +36,8 @@
             <td class="ellipsis text-right">{{address.balance | xcr}} XCR</td>
           </tr>
           <tr>
-              <td><strong>USD equivalent</strong></td>
-              <td class="ellipsis text-right">{{address.usd | fiat}} USD</td>
+            <td><strong>USD equivalent</strong></td>
+            <td class="ellipsis text-right">{{address.usd | fiat}} USD</td>
           </tr>
           </tbody>
         </table>

--- a/public/views/address.html
+++ b/public/views/address.html
@@ -1,4 +1,4 @@
-<section data-ng-controller="AddressController" data-ng-init="findOne()">
+<section data-ng-controller="AddressController">
   <div class="secondary_navbar hidden-xs hidden-sm" scroll data-ng-class="{'hidden': !secondaryNavbar}" data-ng-show="address.address">
     <div class="container" data-ng-hide="!address.balance">
       <div class="col-md-8 text-left">

--- a/public/views/address.html
+++ b/public/views/address.html
@@ -44,7 +44,7 @@
       </div>
     </div>
   </div>
-  <div data-ng-if="address.address" data-ng-controller="transactionsController" data-ng-init="loadTrs('address')">
+  <div data-ng-if="address.address" data-ng-controller="AddressController" data-ng-init="loadTrs('address')">
     <h2>Transactions</h2>
     <div data-ng-include src="'/views/transaction/list.html'" when-scrolled="loadMore()"></div>
   </div>

--- a/public/views/address.html
+++ b/public/views/address.html
@@ -46,6 +46,6 @@
   </div>
   <div data-ng-if="address.address" data-ng-controller="AddressController" data-ng-init="loadTrs('address')">
     <h2>Transactions</h2>
-    <div data-ng-include src="'/views/transaction/list.html'" when-scrolled="loadMore()"></div>
+    <div data-ng-include src="'/views/transaction/list.html'"></div>
   </div>
 </section>

--- a/public/views/address.html
+++ b/public/views/address.html
@@ -44,7 +44,7 @@
       </div>
     </div>
   </div>
-  <div data-ng-if="address.address" data-ng-controller="AddressController" data-ng-init="loadTrs('address')">
+  <div data-ng-if="address.address" data-ng-controller="AddressController" data-ng-init="loadTxs()">
     <h2>Transactions</h2>
     <div data-ng-include src="'/views/transaction/list.html'"></div>
   </div>

--- a/public/views/address.html
+++ b/public/views/address.html
@@ -29,7 +29,7 @@
     <h2>Summary <small>confirmed</small></h2>
     <div class="row" data-ng-hide="!address.address">
       <div class="col-md-12">
-        <table class="table">
+        <table class="table table-responsive">
           <tbody>
           <tr>
             <td><strong>Total balance</strong></td>

--- a/public/views/block.html
+++ b/public/views/block.html
@@ -5,10 +5,9 @@
   </div>
   <div data-ng-if="block.height">
     <div class="well well-sm ellipsis">
-      <strong>Payload Hash</strong>
-      <br>
-      <span class="txid text-muted">{{block.payloadHash}}</span>
-      <span class="btn-copy" clip-copy="block.payloadHash"></span>
+      <strong>Block</strong>
+      <span class="txid text-muted">{{block.id}}</span>
+      <span class="btn-copy" clip-copy="block.id"></span>
     </div>
     <h2>Summary</h2>
     <div class="row">

--- a/public/views/block.html
+++ b/public/views/block.html
@@ -5,7 +5,7 @@
   </div>
   <div data-ng-if="block.height">
     <div class="well well-sm ellipsis">
-      <strong>Block</strong>
+      <strong>Block ID</strong>
       <span class="txid text-muted">{{block.id}}</span>
       <span class="btn-copy" clip-copy="block.id"></span>
     </div>

--- a/public/views/block.html
+++ b/public/views/block.html
@@ -1,4 +1,4 @@
-<section data-ng-controller="BlocksController" data-ng-init="findOne()">
+<section data-ng-controller="BlocksController">
   <h1>Block <small>{{block.id}}</small></h1>
   <div class="text-muted" data-ng-if="!block.height">
     <span>Loading Block <span class="loader-gif"></span>

--- a/public/views/block.html
+++ b/public/views/block.html
@@ -24,9 +24,7 @@
           </tr>
           <tr>
             <td><strong>Height</strong></td>
-            <td class="text-right text-muted">{{block.height}}
-              <span data-ng-show="block.isMainChain" class="text-success">(Mainchain)</span>
-            </td>
+            <td class="text-right text-muted">{{block.height}}</td>
           </tr>
           <tr>
             <td><strong>Total Fee</strong></td>
@@ -66,8 +64,8 @@
         </table>
       </div>
   </div>
-  <div data-ng-if="block.transactions.length > 0" data-ng-controller="transactionsController" data-ng-init="load('block')">
+  <div data-ng-if="block.transactions.length > 0">
     <h3>Transactions</h3>
-    <div data-ng-include src="'/views/transaction/list.html'" when-scrolled="loadMore()"></div>
+    <div data-ng-include src="'/views/transaction/list.html'"></div>
   </div>
 </section>

--- a/public/views/block.html
+++ b/public/views/block.html
@@ -20,8 +20,8 @@
             <td class="text-right text-muted">{{block.numberOfTransactions}}</td>
           </tr>
           <tr>
-              <td><strong>Confirmations</strong></td>
-              <td class="text-right text-muted">{{block.confirmations}}</td>
+            <td><strong>Confirmations</strong></td>
+            <td class="text-right text-muted">{{block.confirmations}}</td>
           </tr>
           <tr>
             <td><strong>Height</strong></td>
@@ -34,28 +34,28 @@
             <td class="text-right text-muted">{{block.totalFee}} XCR</td>
           </tr>
           <tr>
-              <td><strong>Total Amount</strong></td>
-              <td class="text-right text-muted">{{block.totalAmount}} XCR</td>
+            <td><strong>Total Amount</strong></td>
+            <td class="text-right text-muted">{{block.totalAmount}} XCR</td>
           </tr>
           <tr>
-              <td><strong>USD equivalent</strong></td>
-              <td class="text-right text-muted">{{ block.usd }} USD</td>
+            <td><strong>USD equivalent</strong></td>
+            <td class="text-right text-muted">{{ block.usd }} USD</td>
           </tr>
           <tr>
             <td><strong>Timestamp</strong></td>
             <td class="text-right text-muted">{{block.timestamp | timestamp}}</td>
           </tr>
           <tr data-ng-show="block.nextBlock">
-              <td><strong>Next block</strong></td>
-              <td class="text-right text-muted">
-                  <a href="/block/{{ block.nextBlock }}">{{ block.nextBlock }}</a>
-              </td>
+            <td><strong>Next block</strong></td>
+            <td class="text-right text-muted">
+              <a href="/block/{{ block.nextBlock }}">{{ block.nextBlock }}</a>
+            </td>
           </tr>
           <tr data-ng-show="block.previousBlock">
-              <td><strong>Previous block</strong></td>
-              <td class="text-right text-muted">
-                  <a href="/block/{{ block.previousBlock }}">{{ block.previousBlock }}</a>
-              </td>
+            <td><strong>Previous block</strong></td>
+            <td class="text-right text-muted">
+              <a href="/block/{{ block.previousBlock }}">{{ block.previousBlock }}</a>
+            </td>
           </tr>
           <tr>
             <td><strong>Generator</strong></td>

--- a/public/views/block.html
+++ b/public/views/block.html
@@ -1,5 +1,5 @@
 <section data-ng-controller="BlocksController" data-ng-init="findOne()">
-  <h1>Block #{{block.id}}</h1>
+  <h1>Block <small>{{block.id}}</small></h1>
   <div class="text-muted" data-ng-if="!block.height">
     <span>Loading Block <span class="loader-gif"></span>
   </div>

--- a/public/views/block.html
+++ b/public/views/block.html
@@ -12,7 +12,7 @@
     <h2>Summary</h2>
     <div class="row">
       <div class="col-md-12">
-        <table class="table" style="table-layout: fixed">
+        <table class="table table-responsive">
           <tbody>
           <tr>
             <td><strong>Transactions</strong></td>

--- a/public/views/block_list.html
+++ b/public/views/block_list.html
@@ -15,8 +15,8 @@
             <th>Id</th>
             <th class="text-right">Height</th>
             <th class="text-right hidden-xs">Timestamp</th>
-            <th class="text-right hidden-xs"><span class="ellipsis">Transactions</span></th>
-            <th class="text-right hidden-xs hidden-sm"><span class="ellipsis">Generator</span></th>
+            <th class="text-right hidden-xs">Transactions</th>
+            <th class="text-right hidden-xs hidden-sm">Generator</th>
             <th class="text-right hidden-xs hidden-sm">Amount (XCR)</th>
             <th class="text-right hidden-xs hidden-sm">Fee (XCR)</th>
           </tr>

--- a/public/views/block_list.html
+++ b/public/views/block_list.html
@@ -4,7 +4,9 @@
       <div class="page-header">
         <h1>
           Blocks
-          <small>by date. {{detail}} {{before}}</small>
+          <small data-ng-show="blocks.length > 1">
+            {{blocks[0].height}} &#8594; {{blocks[blocks.length - 1].height}}
+          </small>
         </h1>
       </div>
       <table class="table table-hover table-striped" style="table-layout: fixed;">

--- a/public/views/block_list.html
+++ b/public/views/block_list.html
@@ -9,7 +9,7 @@
           </small>
         </h1>
       </div>
-      <table class="table table-hover table-striped" style="table-layout: fixed;">
+      <table class="table table-hover table-striped table-responsive">
         <thead>
           <tr>
             <th>Id</th>

--- a/public/views/block_list.html
+++ b/public/views/block_list.html
@@ -1,4 +1,4 @@
-<section data-ng-controller="BlocksController" data-ng-init="list()">
+<section data-ng-controller="BlocksController">
   <div class="row">
     <div class="col-xs-12 col-md-12">
       <div class="page-header">

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -1,7 +1,7 @@
 <div class="alert alert-danger" data-ng-show="flashMessage">
   {{$root.flashMessage}}
 </div>
-<section data-ng-controller="IndexController" data-ng-init="index()">
+<section data-ng-controller="IndexController">
   <div class="container">
     <div id="home" class="row">
       <div class="col-xs-12 col-md-12">

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -9,7 +9,7 @@
 
         <h2>Latest Transactions</h2>
 
-        <table class="table table-hover table-striped" style="table-layout: fixed;">
+        <table class="table table-hover table-striped table-responsive">
           <thead>
             <tr>
               <th>Id</th>
@@ -31,7 +31,7 @@
 
         <h2>Latest Blocks</h2>
 
-        <table class="table table-hover table-striped" style="table-layout: fixed">
+        <table class="table table-hover table-striped table-responsive">
           <thead>
             <tr>
               <th>Id</th>

--- a/public/views/networkMonitor.html
+++ b/public/views/networkMonitor.html
@@ -151,7 +151,7 @@
     <div class="col-xs-12 big-info">
       <p class="small-title">Peers</p>
 
-      <table class="table table-hover table-striped peers" style="table-layout: fixed;">
+      <table class="table table-hover table-striped table-responsive peers">
         <thead>
           <tr>
             <th>Address</th>

--- a/public/views/networkMonitor.html
+++ b/public/views/networkMonitor.html
@@ -69,7 +69,7 @@
                   <span class="volume-amount">{{volAmount || 0 | xcr}}</span>
                   <span class="text-muted">XCR</span>
                 </p>
-                <p class="text-muted vol-beginning">transferred within {{volBeginning | timeDistance:volNow}}</p>
+                <p class="text-muted vol-beginning">transferred within {{volBeginning | timeSpan:volNow}}</p>
               </div>
             </div>
           </div>

--- a/public/views/networkMonitor.html
+++ b/public/views/networkMonitor.html
@@ -69,7 +69,7 @@
                   <span class="volume-amount">{{volAmount || 0 | xcr}}</span>
                   <span class="text-muted">XCR</span>
                 </p>
-                <p class="text-muted vol-beginning">transferred within {{volBeginning | timeSpan:volNow}}</p>
+                <p class="text-muted vol-beginning">transferred within {{volBeginning | timeSpan:volEnd}}</p>
               </div>
             </div>
           </div>

--- a/public/views/networkMonitor.html
+++ b/public/views/networkMonitor.html
@@ -69,7 +69,7 @@
                   <span class="volume-amount">{{volAmount || 0 | xcr}}</span>
                   <span class="text-muted">XCR</span>
                 </p>
-                <p class="text-muted vol-beginning">transferred within {{volBeginning | timeSpan:volEnd}}</p>
+                <p class="text-muted vol-timespan">transferred within {{volBeginning | timeSpan:volEnd}}</p>
               </div>
             </div>
           </div>

--- a/public/views/networkMonitor.html
+++ b/public/views/networkMonitor.html
@@ -168,7 +168,7 @@
         </tbody>
         <tbody data-ng-repeat='(key, value) in peers'>
           <tr class="fader" data-ng-repeat='p in value track by p.ip'>
-            <td><span class="text-muted">{{p.dottedQuad}}</span></td>
+            <td><span class="text-muted">{{p.ipString}}</span></td>
             <td><span class="peer-state state-{{p.state}}" title="{{p.humanState}}"></span></td>
             <td><span class="text-muted">{{p.version}}</span></td>
             <td><img os-icon os="{{p.os}}" brand="{{p.osBrand}}"></td>

--- a/public/views/networkMonitor.html
+++ b/public/views/networkMonitor.html
@@ -64,10 +64,9 @@
           <div class="row big-info">
             <div class="col-xs-12">
               <div class="pull-left volume">
-                <p class="small-title">Volume</p>
+                <p class="small-title">Volume <span class="text-muted">(XCR)</span></p>
                 <p class="big-details">
                   <span class="volume-amount">{{volAmount || 0 | xcr}}</span>
-                  <span class="text-muted">XCR</span>
                 </p>
                 <p class="text-muted vol-timespan">transferred within {{volBeginning | timeSpan:volEnd}}</p>
               </div>

--- a/public/views/topAccounts.html
+++ b/public/views/topAccounts.html
@@ -6,7 +6,7 @@
   <div data-ng-if="topAccounts">
     <div class="row" data-ng-hide="!topAccounts">
       <div class="col-md-12">
-        <table class="table table-hover table-striped" style="table-layout: fixed;">
+        <table class="table table-hover table-striped table-responsive">
           <thead>
             <tr>
               <th width="5%">Rank</th>

--- a/public/views/topAccounts.html
+++ b/public/views/topAccounts.html
@@ -1,4 +1,4 @@
-<section data-ng-controller="TopAccounts" data-ng-init="findOne()">
+<section data-ng-controller="TopAccounts">
   <h1>Top Accounts</h1>
   <div class="text-muted" data-ng-if="!topAccounts">
     <span>Loading Top Accounts <span class="loader-gif"></span>

--- a/public/views/transaction.html
+++ b/public/views/transaction.html
@@ -39,11 +39,15 @@
         <tbody>
           <tr>
             <td><strong>Sender</strong></td>
-            <td class="text-muted text-right"><a href="/address/{{tx.senderId}}">{{tx.senderId}}</a></td>
+            <td class="text-muted text-right">
+              <a href="/address/{{tx.senderId}}">{{tx.senderId}}</a>
+            </td>
           </tr>
           <tr>
             <td><strong>Recipient</strong></td>
-            <td class="text-muted text-right"><a href="/address/{{tx.recipientId}}">{{tx.recipientId}}</a></td>
+            <td class="text-muted text-right">
+              <a href="/address/{{tx.recipientId}}">{{tx.recipientId}}</a>
+            </td>
           </tr>
           <tr>
             <td><strong>Confirmations</strong></td>
@@ -67,7 +71,9 @@
           </tr>
           <tr>
             <td><strong>Block </strong></td>
-            <td data-ng-show="tx.blockId" class="text-muted text-right"> <a href="/block/{{tx.blockId}}">{{tx.blockId}}</a></td>
+            <td data-ng-show="tx.blockId" class="text-muted text-right">
+              <a href="/block/{{tx.blockId}}">{{tx.blockId}}</a>
+            </td>
             <td data-ng-show="!tx.blockId" class="text-muted text-right">Unconfirmed</td>
           </tr>
         </tbody>

--- a/public/views/transaction.html
+++ b/public/views/transaction.html
@@ -22,7 +22,7 @@
     </div>
   </div>
   <div data-ng-if="tx.id">
-    <h1>Transaction {{tx.id}}</h1>
+    <h1>Transaction <small>{{tx.id}}</small></h1>
     <div class="progress progress-striped active" data-ng-if="!tx.id">
       <div class="progress-bar progress-bar-info" style="width: 100%">
         <span>Loading Transaction <span class="loader-gif"></span>

--- a/public/views/transaction.html
+++ b/public/views/transaction.html
@@ -35,7 +35,7 @@
         <span class="btn-copy" clip-copy="tx.id"></span>
       </div>
       <h2>Summary</h2>
-      <table class="table" style="table-layout: fixed">
+      <table class="table table-responsive">
         <tbody>
           <tr>
             <td><strong>Confirmations</strong></td>

--- a/public/views/transaction.html
+++ b/public/views/transaction.html
@@ -1,4 +1,4 @@
-<section data-ng-controller="transactionsController" data-ng-init="findThis()">
+<section data-ng-controller="TransactionsController" data-ng-init="findThis()">
   <div class="secondary_navbar hidden-xs hidden-sm" scroll data-ng-class="{'hidden': !secondaryNavbar}" data-ng-show="tx.id" data-ng-init="hideSNavbar=0">
     <div class="container" data-ng-if="!hideSNavbar">
       <div class="col-md-6 col-lg-7 text-left">

--- a/public/views/transaction.html
+++ b/public/views/transaction.html
@@ -1,4 +1,4 @@
-<section data-ng-controller="TransactionsController" data-ng-init="findThis()">
+<section data-ng-controller="TransactionsController">
   <div class="secondary_navbar hidden-xs hidden-sm" scroll data-ng-class="{'hidden': !secondaryNavbar}" data-ng-show="tx.id" data-ng-init="hideSNavbar=0">
     <div class="container" data-ng-if="!hideSNavbar">
       <div class="col-md-6 col-lg-7 text-left">

--- a/public/views/transaction.html
+++ b/public/views/transaction.html
@@ -38,18 +38,6 @@
       <table class="table" style="table-layout: fixed">
         <tbody>
           <tr>
-            <td><strong>Sender</strong></td>
-            <td class="text-muted text-right">
-              <a href="/address/{{tx.senderId}}">{{tx.senderId}}</a>
-            </td>
-          </tr>
-          <tr>
-            <td><strong>Recipient</strong></td>
-            <td class="text-muted text-right">
-              <a href="/address/{{tx.recipientId}}">{{tx.recipientId}}</a>
-            </td>
-          </tr>
-          <tr>
             <td><strong>Confirmations</strong></td>
             <td class="text-muted text-right">{{tx.confirmations || 0}}</td>
           </tr>

--- a/public/views/transaction.html
+++ b/public/views/transaction.html
@@ -30,7 +30,7 @@
     </div>
     <div data-ng-if="tx.id">
       <div class="well well-sm ellipsis">
-        <strong>Transaction</strong>
+        <strong>Transaction ID</strong>
         <span class="txid text-muted">{{tx.id}}</span>
         <span class="btn-copy" clip-copy="tx.id"></span>
       </div>

--- a/public/views/transaction/list.html
+++ b/public/views/transaction/list.html
@@ -7,3 +7,11 @@
     <span>Loading Transactions...</span>
   </div>
 </div>
+<div class="btn-group btn-group-justified" role="group" aria-label="Less/More Transactions" data-ng-hide="!lessTxs && !moreTxs">
+  <div class="btn-group" role="group">
+    <button class="btn btn-default" data-ng-disabled="!lessTxs" data-ng-click="loadLess()">Less</a>
+  </div>
+  <div class="btn-group" role="group">
+    <button class="btn btn-default" data-ng-disabled="!moreTxs" data-ng-click="loadMore()">More</a>
+  </div>
+</div>

--- a/public/views/transaction/tx.html
+++ b/public/views/transaction/tx.html
@@ -8,27 +8,14 @@
 </div>
 <div class="row line-mid">
   <div class="col-md-5">
-    <div class="row" data-ng-if="!tx.isCoinBase">
-
-      <!-- <<< Simple view -->
-      <div data-ng-if="!itemsExpanded" data-ng-init="currentInNoExpanded=0; sizeInNoExpanded=5">
-        <div class="panel panel-default">
-          <div class="panel-body transaction-vin-vout">
-            <div class="pull-right btc-value" data-ng-class="{'text-danger': $root.currentAddr == tx.senderId}">{{tx.amount | xcr}} XCR</div>
-            <div class="ellipsis">
-              <span class="text-muted" title="Current XCR Address" data-ng-show="tx.senderId == $root.currentAddr">{{tx.senderId}}</span>
-              <a href="/address/{{tx.senderId}}" data-ng-show="tx.senderId != $root.currentAddr">{{tx.senderId}}</a>
-            </div>
-            <div data-ng-show="vin.unconfirmedInput" class="text-danger"> <span class="glyphicon glyphicon-warning-sign"></span> (Input unconfirmed)</div>
-            <div data-ng-show="vin.dbError" class="text-danger"> <span class="glyphicon glyphicon-warning-sign"></span> Incoherence in levelDB detected: {{vin.dbError}}</div>
-            <div data-ng-show="vin.doubleSpentTxID" class="text-danger"> <span class="glyphicon glyphicon-warning-sign"></span> Double spent attempt detected. From tx:
-              <a href="/tx/{{vin.doubleSpentTxID}}">{{vin.doubleSpentTxID}},{{vin.doubleSpentIndex}}</a>
-            </div>
+    <div class="row">
+      <div class="panel panel-default">
+        <div class="panel-body">
+          <div class="pull-right" data-ng-class="{'text-danger': $root.currentAddr == tx.senderId}">{{tx.amount | xcr}} XCR</div>
+          <div class="ellipsis">
+            <span class="text-muted" data-ng-show="tx.senderId == $root.currentAddr">{{tx.senderId}}</span>
+            <a href="/address/{{tx.senderId}}" data-ng-show="tx.senderId != $root.currentAddr">{{tx.senderId}}</a>
           </div>
-        </div>
-        <div class="showmore_collapse text-left" data-ng-show="tx.vinSimple.length > 5" data-ng-class="{ 'hidden': itemsExpanded}">
-          <button type="button" class="btn btn-info btn-sm" ng-hide="sizeInNoExpanded != tx.vinSimple.length" ng-click="currentInNoExpanded=0; sizeInNoExpanded=5"><i class="glyphicon glyphicon-chevron-up"></i> Show less</button>
-          <button type="button" class="btn btn-info btn-sm" ng-hide="currentInNoExpanded >= tx.vinSimple.length/sizeInNoExpanded - 1" ng-click="currentInNoExpanded=0; sizeInNoExpanded=tx.vinSimple.length"><i class="glyphicon glyphicon-chevron-down"></i> Show more</button>
         </div>
       </div>
     </div>
@@ -43,87 +30,25 @@
   </div>
   <div class="col-md-6">
     <div class="row">
-      <!-- Simple view >>> -->
-      <div data-ng-if="!itemsExpanded" data-ng-init="currentOutNoExpanded=0; sizeOutNoExpanded=5">
-        <div>
-          <div class="transaction-vin-vout panel panel-default">
-            <div class="panel-body">
-              <div class="pull-right btc-value" data-ng-class="{'text-success': $root.currentAddr == tx.recipientId}">{{tx.amount | xcr}} XCR</div>
-
-              <div class="ellipsis" ng-show="tx.type == 0 && tx.subtype == 0">
-                <a href="/address/{{tx.recipientId}}" data-ng-show="tx.senderId != $root.currentAddr">{{tx.recipientId}}</a>
-              </div>
-              <div class="ellipsis" ng-show="tx.type == 1 && tx.subtype == 0">
-                  {{tx.recipientId}}
-              </div>
-              <div class="ellipsis" ng-show="tx.type == 2 && tx.subtype == 0">
-                  Second signature creation
-              </div>
-              <div class="ellipsis" ng-show="tx.type == 3 && tx.subtype == 0">
-                  Company creation
-              </div>
+      <div>
+        <div class="panel panel-default">
+          <div class="panel-body">
+            <div class="pull-right" data-ng-class="{'text-success': $root.currentAddr == tx.recipientId}">{{tx.amount | xcr}} XCR</div>
+            <div class="ellipsis" ng-show="tx.type == 0 && tx.subtype == 0">
+              <a href="/address/{{tx.recipientId}}" data-ng-show="tx.senderId != $root.currentAddr">{{tx.recipientId}}</a>
+            </div>
+            <div class="ellipsis" ng-show="tx.type == 1 && tx.subtype == 0">
+                {{tx.recipientId}}
+            </div>
+            <div class="ellipsis" ng-show="tx.type == 2 && tx.subtype == 0">
+                Second signature creation
+            </div>
+            <div class="ellipsis" ng-show="tx.type == 3 && tx.subtype == 0">
+                Company creation
             </div>
           </div>
-        </div>
-        <div class="showmore_collapse text-left" data-ng-show="tx.voutSimple.length > 5" data-ng-class="{ 'hidden': itemsExpanded}">
-          <button type="button" class="btn btn-info btn-sm" ng-hide="sizeOutNoExpanded != tx.voutSimple.length" ng-click="currentOutNoExpanded=0; sizeOutNoExpanded=5"><i class="glyphicon glyphicon-chevron-up"></i> Show less</button>
-          <button type="button" class="btn btn-info btn-sm" ng-hide="currentOutNoExpanded >= tx.voutSimple.length/sizeOutNoExpanded - 1" ng-click="currentOutNoExpanded=0; sizeOutNoExpanded=tx.voutSimple.length"><i class="glyphicon glyphicon-chevron-down"></i> Show more</button>
-        </div>
-      </div>
-
-      <!-- Full view >>> -->
-      <div data-ng-if="itemsExpanded" data-ng-init="currentOutExpanded=0; sizeOutExpanded=(from_vout) ? tx.vout.length : 5; fromVoutCollapsed=(from_vout)">
-        <div data-ng-repeat="vout in tx.vout| startFrom:currentOutExpanded*sizeOutExpanded | limitTo:sizeOutExpanded" data-ng-if="fromVoutCollapsed ? v_index == vout.n : 1">
-          <div class="panel panel-default transaction-vin-vout">
-            <div class="panel-body">
-              <div class="pull-right btc-value">
-                <span>{{$root.currency.getConvertion(vout.value) || vout.value + ' BTC'}}
-                  <span class="text-success" data-ng-show="!vout.spentTxId" tooltip="Output is unspent" tooltip-placement="left">(U)</span>
-                  <a class="glyphicon glyphicon-chevron-right" data-ng-show="vout.spentTxId" href="/tx/{{vout.spentTxId}}/</{{vout.spentIndex}}" title="Spent at: {{vout.spentTxId}},{{vout.spentIndex}}"></a>
-                </span>
-              </div>
-              <div class="ellipsis">
-                <a href="/address/{{address}}" data-ng-repeat="address in vout.scriptPubKey.addresses">{{address}}</a>
-              </div>
-            </div>
-          </div>
-          <div style="padding-left: 0.7em; padding-bottom: 2em; word-wrap:break-word" data-ng-class="{true: 'v_highlight', false: ''}[from_vout == true && v_index == vout.n]">
-              <p class="small">
-                <strong>Type</strong>
-                <span class="text-muted">{{vout.scriptPubKey.type}}</span>
-              </p>
-              <div class="small">
-                <p><strong>scriptPubKey</strong></p>
-                <span class="col-md-11 text-muted ellipsis">{{vout.scriptPubKey.asm}}</span>
-                <span class="btn-copy col-md-1" clip-copy="vout.scriptPubKey.asm"></span>
-              </div>
-          </div>
-        </div>
-        <div class="text-right">
-          <button type="button" class="btn btn-default btn-sm" data-ng-show="(from_vout) && tx.vout.length > 1" data-ng-disabled="fromVoutCollapsed" data-ng-click="currentOutExpanded=0; sizeOutExpanded=tx.vout.length;fromVoutCollapsed=1">Show output #{{ v_index }}</button>
-          <button type="button" class="btn btn-default btn-sm" data-ng-show="(from_vout) && tx.vout.length > 1" data-ng-disabled="!fromVoutCollapsed" data-ng-click="currentOutExpanded=0; sizeOutExpanded=tx.vout.length;fromVoutCollapsed=0">Show all</button>
-        </div>
-        <div class="showmore_collapse text-left" data-ng-show="tx.vout.length > 5 && !fromVoutCollapsed" data-ng-class="{ 'hidden': !itemsExpanded}">
-          <button type="button" class="btn btn-info btn-sm" ng-hide="sizeOutExpanded != tx.vout.length" ng-click="currentOutExpanded=0; sizeOutExpanded=5"><i class="glyphicon glyphicon-chevron-up"></i>Show less</button>
-          <button type="button" class="btn btn-info btn-sm" ng-hide="currentOutExpanded >= tx.vout.length/sizeOutExpanded - 1" ng-click="currentOutExpanded=0; sizeOutExpanded=tx.vout.length"><i class="glyphicon glyphicon-chevron-down"></i> Show more</button>
         </div>
       </div>
     </div>
-  </div>
-</div>
-
-<div class="well well-sm bgwhite ellipsis" data-ng-if="itemsExpanded && !block.id && tx.blockId">
-  <strong>Included in Block</strong> <a class="text-muted" href="/block/{{tx.blockhash}}">{{tx.blockhash}}</a>
-  <span class="btn-copy" clip-copy="tx.blockhash"></span>
-</div>
-
-<div class="line-top row" data-ng-hide="!tx">
-  <div class="col-xs-12 col-sm-4 col-md-4">
-    <span data-ng-show="!tx.isCoinBase &&  !isNaN(parseFloat(tx.fee))" class="txvalues txvalues-default">Fees: {{tx.fee | xcr}} XCR</span>
-  </div>
-  <div class="col-xs-12 col-sm-8 col-md-8 text-right">
-    <span data-ng-show="block.confirmations > 0 || tx.confirmations > 0" class="txvalues txvalues-success">{{block.confirmations || tx.confirmations}} Confirmations</span>
-    <span data-ng-show="!block.confirmations && !tx.confirmations" class="txvalues txvalues-danger">Unconfirmed Transaction!</span>
-    <span class="txvalues txvalues-primary">{{tx.amount | xcr}} XCR</span>
   </div>
 </div>

--- a/public/views/transaction/tx.html
+++ b/public/views/transaction/tx.html
@@ -54,7 +54,7 @@
 </div>
 <div class="line-top row" data-ng-hide="!tx">
   <div class="col-xs-12 col-sm-4 col-md-4">
-    <span data-ng-show="!isNaN(parseFloat(tx.fee))" class="txvalues txvalues-default">Fee: {{tx.fee | xcr}} XCR</span>
+    <span class="txvalues txvalues-default">Fee: {{tx.fee | xcr}} XCR</span>
   </div>
   <div class="col-xs-12 col-sm-8 col-md-8 text-right">
     <span data-ng-show="block.confirmations > 0 || tx.confirmations > 0" class="txvalues txvalues-success">{{block.confirmations || tx.confirmations}} Confirmations</span>

--- a/public/views/transaction/tx.html
+++ b/public/views/transaction/tx.html
@@ -7,7 +7,6 @@
   </div>
   <div class="col-xs-5">
     <div class="ellipsis text-right">
-      <span class="text-muted glyphicon glyphicon-time"></span>
       <span class="text-muted">{{tx.timestamp | timeAgo }}</span>
     </div>
   </div>

--- a/public/views/transaction/tx.html
+++ b/public/views/transaction/tx.html
@@ -54,7 +54,7 @@
 </div>
 <div class="line-top row" data-ng-hide="!tx">
   <div class="col-xs-12 col-sm-4 col-md-4">
-    <span data-ng-show="!isNaN(parseFloat(tx.fee))" class="txvalues txvalues-default">Fees: {{tx.fee | xcr}} XCR</span>
+    <span data-ng-show="!isNaN(parseFloat(tx.fee))" class="txvalues txvalues-default">Fee: {{tx.fee | xcr}} XCR</span>
   </div>
   <div class="col-xs-12 col-sm-8 col-md-8 text-right">
     <span data-ng-show="block.confirmations > 0 || tx.confirmations > 0" class="txvalues txvalues-success">{{block.confirmations || tx.confirmations}} Confirmations</span>

--- a/public/views/transaction/tx.html
+++ b/public/views/transaction/tx.html
@@ -37,15 +37,9 @@
             <div class="ellipsis" ng-show="tx.type == 0 && tx.subtype == 0">
               <a href="/address/{{tx.recipientId}}" data-ng-show="tx.senderId != $root.currentAddr">{{tx.recipientId}}</a>
             </div>
-            <div class="ellipsis" ng-show="tx.type == 1 && tx.subtype == 0">
-                {{tx.recipientId}}
-            </div>
-            <div class="ellipsis" ng-show="tx.type == 2 && tx.subtype == 0">
-                Second signature creation
-            </div>
-            <div class="ellipsis" ng-show="tx.type == 3 && tx.subtype == 0">
-                Company creation
-            </div>
+            <div class="ellipsis" ng-show="tx.type == 1 && tx.subtype == 0">{{tx.recipientId}}</div>
+            <div class="ellipsis" ng-show="tx.type == 2 && tx.subtype == 0">Second signature creation</div>
+            <div class="ellipsis" ng-show="tx.type == 3 && tx.subtype == 0">Company creation</div>
           </div>
         </div>
       </div>

--- a/public/views/transaction/tx.html
+++ b/public/views/transaction/tx.html
@@ -1,8 +1,14 @@
 <div class="line-bot row" data-ng-hide="!tx">
-  <div class="col-xs-12 col-md-8">
+  <div class="col-xs-7">
     <div class="ellipsis">
       <a class="txid" href="/tx/{{tx.id}}">{{tx.id}}</a>
       <span class="btn-copy" clip-copy="tx.id"></span>
+    </div>
+  </div>
+  <div class="col-xs-5">
+    <div class="ellipsis text-right">
+      <span class="text-muted glyphicon glyphicon-time"></span>
+      <span class="text-muted">{{tx.timestamp | timeAgo }}</span>
     </div>
   </div>
 </div>

--- a/public/views/transaction/tx.html
+++ b/public/views/transaction/tx.html
@@ -12,7 +12,7 @@
     </div>
   </div>
 </div>
-<div class="row line-mid">
+<div class="row line-mid" data-ng-hide="!tx">
   <div class="col-md-5">
     <div class="row">
       <div class="panel panel-default">

--- a/public/views/transaction/tx.html
+++ b/public/views/transaction/tx.html
@@ -52,3 +52,13 @@
     </div>
   </div>
 </div>
+<div class="line-top row" data-ng-hide="!tx">
+  <div class="col-xs-12 col-sm-4 col-md-4">
+    <span data-ng-show="!isNaN(parseFloat(tx.fee))" class="txvalues txvalues-default">Fees: {{tx.fee | xcr}} XCR</span>
+  </div>
+  <div class="col-xs-12 col-sm-8 col-md-8 text-right">
+    <span data-ng-show="block.confirmations > 0 || tx.confirmations > 0" class="txvalues txvalues-success">{{block.confirmations || tx.confirmations}} Confirmations</span>
+    <span data-ng-show="!block.confirmations && !tx.confirmations" class="txvalues txvalues-danger">Unconfirmed Transaction!</span>
+    <span class="txvalues txvalues-primary">{{tx.amount | xcr}} XCR</span>
+  </div>
+</div>

--- a/sockets/index.js
+++ b/sockets/index.js
@@ -7,8 +7,8 @@ module.exports = function (app, io) {
     var activityGraph  = require('./activityGraph'),
         networkMonitor = require('./networkMonitor');
 
-    var connectionHandler = function (name, socket, object) {
-        socket.on('connection', function (socket) {
+    var connectionHandler = function (name, ns, object) {
+        ns.on('connection', function (socket) {
             if (clients() <= 1) {
                 object.onInit();
                 console.log(name, 'First connection');
@@ -27,7 +27,7 @@ module.exports = function (app, io) {
         // Private
 
         var clients = function () {
-            return Object.keys(socket.connected).length;
+            return Object.keys(ns.connected).length;
         }
     }
 

--- a/sockets/index.js
+++ b/sockets/index.js
@@ -22,6 +22,9 @@ module.exports = function (app, io) {
                     console.log(name, 'Closed connection');
                 }
             });
+            socket.on('locationChange', function () {
+                socket.disconnect();
+            });
         });
 
         // Private

--- a/sockets/index.js
+++ b/sockets/index.js
@@ -22,7 +22,7 @@ module.exports = function (app, io) {
                     console.log(name, 'Closed connection');
                 }
             });
-            socket.on('locationChange', function () {
+            socket.on('forceDisconnect', function () {
                 socket.disconnect();
             });
         });

--- a/sockets/index.js
+++ b/sockets/index.js
@@ -8,26 +8,27 @@ module.exports = function (app, io) {
         networkMonitor = require('./networkMonitor');
 
     var connectionHandler = function (name, socket, object) {
-        var clients = 0;
         socket.on('connection', function (socket) {
-            if (clients <= 0) {
-                clients = 0;
+            if (clients() <= 1) {
                 object.onInit();
                 console.log(name, 'First connection');
             } else {
                 object.onConnect();
                 console.log(name, 'New connection');
             }
-            clients++;
             socket.on('disconnect', function () {
-                clients--;
-                if (clients <= 0) {
-                    clients = 0;
+                if (clients() <= 0) {
                     object.onDisconnect();
                     console.log(name, 'Closed connection');
                 }
             });
         });
+
+        // Private
+
+        var clients = function () {
+            return Object.keys(socket.connected).length;
+        }
     }
 
     new activityGraph(app, connectionHandler, ns.activityGraph);

--- a/utils/exchange-api/index.js
+++ b/utils/exchange-api/index.js
@@ -35,6 +35,17 @@ module.exports = function (config) {
             ]
         },
         XCRBTC : {
+            bter : [
+                "Bter",
+                "http://data.bter.com/api/1/ticker/xcr_btc",
+                function (res, cb) {
+                    if (res.message) {
+                        return cb(res.message);
+                    } else {
+                        return cb(null, res.last);
+                    }
+                }
+            ],
             cryptsy : [
                 "Cryptsy",
                 "http://pubapi.cryptsy.com/api.php?method=singlemarketdata&marketid=280",

--- a/utils/exchange.js
+++ b/utils/exchange.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function(config) {
+module.exports = function (config) {
     this.BTCUSD = this.XCRBTC = "~";
 
     this.loadRates = function () {

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,5 +1,4 @@
 module.exports = {
     topAccounts : require('./topAccounts.js'),
-    time : require('./time.js'),
     exchange : require('./exchange.js')
 }

--- a/utils/time.js
+++ b/utils/time.js
@@ -1,9 +1,0 @@
-var moment = require('moment');
-
-module.exports = {
-    getTime : function (timestamp) {
-        var d = new Date(Date.UTC(2014, 4, 2, 0, 0, 0, 0));
-        var t = d.getTime();
-        return parseInt((timestamp - t) / 1000);
-    }
-}


### PR DESCRIPTION
### Changelog
#### UI / CSS
- Making all tables behave more responsively
- Fixing background-position of crypti logo
#### Exchanges
- Reinstating Bter as an optional XCR/BTC exchange  
  (Please see: https://github.com/karmacoma/cryptichain#configuration)
#### Activity Graph
- Fixing null recipients for special transaction types
#### Network Monitor
- Adding map marker popups
- Validating geo-location data on receipt before trying to use it
- Implementing in-memory geo-location cache. Prevents repeated querying of the freegeoip server
- Fixing ReferenceError: next is not defined in getLastBlock
#### Socket-io

This group of fixes, ensure when a user changes page, but remains on-site. Existing socket connections to each namespace (networkGraph, activityGraph) are immediately closed. When a user returns to the one of the pages, a new connection is made and they do not have wait for the next data emission.
- Counting clients by actual connection id
- Firing disconnect event on location change
- Forcing new connection after location change
#### Transactions
- Adding time ago to each transaction (gives better context)
- Paginating transactions belonging to an address.
  - Transactions per page: 20
  - Maximum transactions: 1000

(For example: http://cryptichain.me/address/1064014217195323888C)

When fetching more transactions: Any newly confirmed transactions since accessing the page will trigger a reload of the existing resultset.
